### PR TITLE
Implement numpy support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 python:
+  - "3.6"
   - "3.5"
   - "3.4"
   - "3.3"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,15 @@ python:
   - "2.7"
   - "2.6"
 
-script:  py.test -v
+install:
+  - pip install pytest-cov codecov
+
+script:
+  - pip install --no-deps -e .
+  - py.test -v --cov=utm
+
+after_success:
+  - codecov
 
 deploy:
   provider: pypi

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,13 @@ python:
   - "3.3"
   - "2.7"
   - "2.6"
+env:
+  - USE_NUMPY=0
+  - USE_NUMPY=1
 
 install:
+  - if [[ $USE_NUMPY == 0 ]]; then pip uninstall numpy --yes; fi
+  - if [[ $USE_NUMPY == 1 ]]; then pip install --upgrade numpy; fi
   - pip install pytest-cov codecov
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
 
 install:
   - if [[ $USE_NUMPY == 0 ]]; then pip uninstall numpy --yes; fi
-  - if [[ $USE_NUMPY == 1 ]]; then pip install --upgrade numpy; fi
+  - if [[ $USE_NUMPY == 1 ]]; then pip install numpy; fi  # Don't upgrade if present
   - pip install pytest-cov codecov
 
 script:

--- a/utm/conversion.py
+++ b/utm/conversion.py
@@ -1,5 +1,13 @@
-import math
 from utm.error import OutOfRangeError
+
+# For most use cases in this module, numpy is indistinguishable
+# from math, except it also works on numpy arrays
+try:
+    import numpy as mathlib
+    use_numpy = True
+except ImportError:
+    import math as mathlib
+    use_numpy = False
 
 __all__ = ['to_latlon', 'from_latlon']
 
@@ -10,7 +18,7 @@ E2 = E * E
 E3 = E2 * E
 E_P2 = E / (1.0 - E)
 
-SQRT_E = math.sqrt(1 - E)
+SQRT_E = mathlib.sqrt(1 - E)
 _E = (1 - SQRT_E) / (1 + SQRT_E)
 _E2 = _E * _E
 _E3 = _E2 * _E
@@ -30,6 +38,26 @@ P5 = (1097. / 512 * _E4)
 R = 6378137
 
 ZONE_LETTERS = "CDEFGHJKLMNPQRSTUVWXX"
+
+
+def in_bounds(x, lower, upper, upper_strict=False):
+    if upper_strict and use_numpy:
+        return lower <= mathlib.min(x) and mathlib.max(x) < upper
+    elif upper_strict and not use_numpy:
+        return lower <= x < upper
+    elif use_numpy:
+        return lower <= mathlib.min(x) and mathlib.max(x) <= upper
+    return lower <= x <= upper
+
+
+def mixed_signs(x):
+    return use_numpy and mathlib.min(x) < 0 and mathlib.max(x) >= 0
+
+
+def negative(x):
+    if use_numpy:
+        return mathlib.max(x) < 0
+    return x < 0
 
 
 def to_latlon(easting, northing, zone_number, zone_letter=None, northern=None, strict=True):
@@ -65,9 +93,9 @@ def to_latlon(easting, northing, zone_number, zone_letter=None, northern=None, s
         raise ValueError('set either zone_letter or northern, but not both')
 
     if strict:
-        if not 100000 <= easting < 1000000:
+        if not in_bounds(easting, 100000, 1000000, upper_strict=True):
             raise OutOfRangeError('easting out of range (must be between 100.000 m and 999.999 m)')
-        if not 0 <= northing <= 10000000:
+        if not in_bounds(northing, 0, 10000000):
             raise OutOfRangeError('northing out of range (must be between 0 m and 10.000.000 m)')
     if not 1 <= zone_number <= 60:
         raise OutOfRangeError('zone number out of range (must be between 1 and 60)')
@@ -90,22 +118,22 @@ def to_latlon(easting, northing, zone_number, zone_letter=None, northern=None, s
     mu = m / (R * M1)
 
     p_rad = (mu +
-             P2 * math.sin(2 * mu) +
-             P3 * math.sin(4 * mu) +
-             P4 * math.sin(6 * mu) +
-             P5 * math.sin(8 * mu))
+             P2 * mathlib.sin(2 * mu) +
+             P3 * mathlib.sin(4 * mu) +
+             P4 * mathlib.sin(6 * mu) +
+             P5 * mathlib.sin(8 * mu))
 
-    p_sin = math.sin(p_rad)
+    p_sin = mathlib.sin(p_rad)
     p_sin2 = p_sin * p_sin
 
-    p_cos = math.cos(p_rad)
+    p_cos = mathlib.cos(p_rad)
 
     p_tan = p_sin / p_cos
     p_tan2 = p_tan * p_tan
     p_tan4 = p_tan2 * p_tan2
 
     ep_sin = 1 - E * p_sin2
-    ep_sin_sqrt = math.sqrt(1 - E * p_sin2)
+    ep_sin_sqrt = mathlib.sqrt(1 - E * p_sin2)
 
     n = R / ep_sin_sqrt
     r = (1 - E) / ep_sin
@@ -129,11 +157,11 @@ def to_latlon(easting, northing, zone_number, zone_letter=None, northern=None, s
                  d3 / 6 * (1 + 2 * p_tan2 + c) +
                  d5 / 120 * (5 - 2 * c + 28 * p_tan2 - 3 * c2 + 8 * E_P2 + 24 * p_tan4)) / p_cos
 
-    return (math.degrees(latitude),
-            math.degrees(longitude) + zone_number_to_central_longitude(zone_number))
+    return (mathlib.degrees(latitude),
+            mathlib.degrees(longitude) + zone_number_to_central_longitude(zone_number))
 
 
-def from_latlon(latitude, longitude, force_zone_number=None):
+def from_latlon(latitude, longitude, force_zone_number=None, force_zone_letter=None):
     """This function convert Latitude and Longitude to UTM coordinate
 
         Parameters
@@ -151,14 +179,14 @@ def from_latlon(latitude, longitude, force_zone_number=None):
 
        .. _[1]: http://www.jaworski.ca/utmzones.htm
     """
-    if not -80.0 <= latitude <= 84.0:
+    if not in_bounds(latitude, -80.0, 84.0):
         raise OutOfRangeError('latitude out of range (must be between 80 deg S and 84 deg N)')
-    if not -180.0 <= longitude <= 180.0:
+    if not in_bounds(longitude, -180.0, 180.0):
         raise OutOfRangeError('longitude out of range (must be between 180 deg W and 180 deg E)')
 
-    lat_rad = math.radians(latitude)
-    lat_sin = math.sin(lat_rad)
-    lat_cos = math.cos(lat_rad)
+    lat_rad = mathlib.radians(latitude)
+    lat_sin = mathlib.sin(lat_rad)
+    lat_cos = mathlib.cos(lat_rad)
 
     lat_tan = lat_sin / lat_cos
     lat_tan2 = lat_tan * lat_tan
@@ -169,13 +197,16 @@ def from_latlon(latitude, longitude, force_zone_number=None):
     else:
         zone_number = force_zone_number
 
-    zone_letter = latitude_to_zone_letter(latitude)
+    if force_zone_letter is None:
+        zone_letter = latitude_to_zone_letter(latitude)
+    else:
+        zone_letter = force_zone_letter
 
-    lon_rad = math.radians(longitude)
+    lon_rad = mathlib.radians(longitude)
     central_lon = zone_number_to_central_longitude(zone_number)
-    central_lon_rad = math.radians(central_lon)
+    central_lon_rad = mathlib.radians(central_lon)
 
-    n = R / math.sqrt(1 - E * lat_sin**2)
+    n = R / mathlib.sqrt(1 - E * lat_sin**2)
     c = E_P2 * lat_cos**2
 
     a = lat_cos * (lon_rad - central_lon_rad)
@@ -186,9 +217,9 @@ def from_latlon(latitude, longitude, force_zone_number=None):
     a6 = a5 * a
 
     m = R * (M1 * lat_rad -
-             M2 * math.sin(2 * lat_rad) +
-             M3 * math.sin(4 * lat_rad) -
-             M4 * math.sin(6 * lat_rad))
+             M2 * mathlib.sin(2 * lat_rad) +
+             M3 * mathlib.sin(4 * lat_rad) -
+             M4 * mathlib.sin(6 * lat_rad))
 
     easting = K0 * n * (a +
                         a3 / 6 * (1 - lat_tan2 + c) +
@@ -198,13 +229,20 @@ def from_latlon(latitude, longitude, force_zone_number=None):
                                         a4 / 24 * (5 - lat_tan2 + 9 * c + 4 * c**2) +
                                         a6 / 720 * (61 - 58 * lat_tan2 + lat_tan4 + 600 * c - 330 * E_P2)))
 
-    if latitude < 0:
+    if mixed_signs(latitude):
+        raise ValueError("latitudes must all have the same sign")
+    elif negative(latitude):
         northing += 10000000
 
     return easting, northing, zone_number, zone_letter
 
 
 def latitude_to_zone_letter(latitude):
+    # If the input is a numpy array, just use the first element
+    # User responsibility to make sure that all points are in one zone
+    if use_numpy and isinstance(latitude, mathlib.ndarray):
+        latitude = latitude.flat[0]
+
     if -80 <= latitude <= 84:
         return ZONE_LETTERS[int(latitude + 80) >> 3]
     else:
@@ -212,6 +250,14 @@ def latitude_to_zone_letter(latitude):
 
 
 def latlon_to_zone_number(latitude, longitude):
+    # If the input is a numpy array, just use the first element
+    # User responsibility to make sure that all points are in one zone
+    if use_numpy:
+        if isinstance(latitude, mathlib.ndarray):
+            latitude = latitude.flat[0]
+        if isinstance(longitude, mathlib.ndarray):
+            longitude = longitude.flat[0]
+
     if 56 <= latitude < 64 and 3 <= longitude < 12:
         return 32
 


### PR DESCRIPTION
It was deemed “out of scope” in https://github.com/Turbo87/utm/issues/18 but it's actually very simple to do and doubtless a useful feature. For people like me who are working with heightmaps with thousands of points in each direction in different coordinate systems, converting coordinate pairs one-by-one is unacceptably slow.

In principle, the numpy module implements all the functions that are needed from math, and they work transparently for arrays as well as floats, so it's a drop-in replacement.

Exceptions:
- Bounds checking, I delegated this to a helper function that catches all cases.
- Possibly ambiguous input in the zone calculation in from_latlon. Here I just use the first point to compute the zone, assuming that the user is careful enough to have all points in the same zone (or that they will be fine with having input points in one zone converted to UTM coordinates in another).
- Mixed north/south latitudes in from_latlon. Right now the code throws an exception in this case. However now that I think about it, I assume it would be correct to add 10e6 northing to every point with a southern latitude and to not change the northern latitude points? If so I can modify this to work without throwing an error.

I wrote the tests to require numpy since it's safer. Not sure what Travis will think of this so let's see…

I'm already using this modified version in my code so it's not critical to me that this is merged, but I'm fairly sure this would be useful to others.
