### PR TITLE
Add zone checking when forced

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ MANIFEST
 pip-log.txt
 
 # Unit test / coverage reports
+.pytest_cache
 .coverage
 .tox
 nosetests.xml

--- a/test/test_utm.py
+++ b/test/test_utm.py
@@ -303,6 +303,25 @@ class TestRightBoundaries(unittest.TestCase):
         self.assert_zone_equal(UTM.from_latlon(72, 8.999999), 31)
         self.assert_zone_equal(UTM.from_latlon(72, 9), 33)
 
+
+class TestValidZones(unittest.TestCase):
+    def test_valid_zones(self):
+        # should not raise any exceptions
+        UTM.check_valid_zone(10, 'C')
+        UTM.check_valid_zone(10, 'X')
+        UTM.check_valid_zone(10, 'p')
+        UTM.check_valid_zone(10, 'q')
+        UTM.check_valid_zone(20, 'X')
+        UTM.check_valid_zone(1, 'X')
+        UTM.check_valid_zone(60, 'e')
+
+    def test_invalid_zones(self):
+        self.assertRaises(UTM.OutOfRangeError, UTM.check_valid_zone, -100, 'C')
+        self.assertRaises(UTM.OutOfRangeError, UTM.check_valid_zone, 20, 'I')
+        self.assertRaises(UTM.OutOfRangeError, UTM.check_valid_zone, 20, 'O')
+        self.assertRaises(UTM.OutOfRangeError, UTM.check_valid_zone, 0, 'O')
+
+
 class TestForcingZones(unittest.TestCase):
     def assert_zone_equal(self, result, expected_number, expected_letter):
         self.assertEqual(result[2], expected_number)
@@ -312,6 +331,9 @@ class TestForcingZones(unittest.TestCase):
         # test forcing zone ranges
         # NYC should be zone 18T
         self.assert_zone_equal(UTM.from_latlon(40.71435, -74.00597, 19, 'T'), 19, 'T')
+        self.assert_zone_equal(UTM.from_latlon(40.71435, -74.00597, 17, 'T'), 17, 'T')
+        self.assert_zone_equal(UTM.from_latlon(40.71435, -74.00597, 18, 'u'), 18, 'U')
+        self.assert_zone_equal(UTM.from_latlon(40.71435, -74.00597, 18, 'S'), 18, 'S')
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_utm.py
+++ b/test/test_utm.py
@@ -155,6 +155,11 @@ class BadInput(UTMTestCase):
         self.assertRaises(UTM.OutOfRangeError, UTM.from_latlon, -100, 300)
         self.assertRaises(UTM.OutOfRangeError, UTM.from_latlon, 100, 300)
 
+        # test forcing zone ranges
+        # NYC should be zone 18T
+        self.assertRaises(UTM.OutOfRangeError, UTM.from_latlon, 40.71435, -74.00597, 70, 'T')
+        self.assertRaises(UTM.OutOfRangeError, UTM.from_latlon, 40.71435, -74.00597, 18, 'A')
+
     def test_to_latlon_range_checks(self):
         '''to_latlon should fail with out-of-bounds input'''
 
@@ -298,6 +303,15 @@ class TestRightBoundaries(unittest.TestCase):
         self.assert_zone_equal(UTM.from_latlon(72, 8.999999), 31)
         self.assert_zone_equal(UTM.from_latlon(72, 9), 33)
 
+class TestForcingZones(unittest.TestCase):
+    def assert_zone_equal(self, result, expected_number, expected_letter):
+        self.assertEqual(result[2], expected_number)
+        self.assertEqual(result[3].upper(), expected_letter.upper())
+
+    def test_force_zone(self):
+        # test forcing zone ranges
+        # NYC should be zone 18T
+        self.assert_zone_equal(UTM.from_latlon(40.71435, -74.00597, 19, 'T'), 19, 'T')
 
 if __name__ == '__main__':
     unittest.main()

--- a/utm/__init__.py
+++ b/utm/__init__.py
@@ -1,2 +1,2 @@
-from utm.conversion import to_latlon, from_latlon, latlon_to_zone_number, latitude_to_zone_letter
+from utm.conversion import to_latlon, from_latlon, latlon_to_zone_number, latitude_to_zone_letter, check_valid_zone
 from utm.error import OutOfRangeError

--- a/utm/conversion.py
+++ b/utm/conversion.py
@@ -50,6 +50,17 @@ def in_bounds(x, lower, upper, upper_strict=False):
     return lower <= x <= upper
 
 
+def check_valid_zone(zone_number, zone_letter):
+    if not 1 <= zone_number <= 60:
+        raise OutOfRangeError('zone number out of range (must be between 1 and 60)')
+
+    if zone_letter:
+        zone_letter = zone_letter.upper()
+
+        if not 'C' <= zone_letter <= 'X' or zone_letter in ['I', 'O']:
+            raise OutOfRangeError('zone letter out of range (must be between C and X)')
+
+
 def mixed_signs(x):
     return use_numpy and mathlib.min(x) < 0 and mathlib.max(x) >= 0
 
@@ -97,15 +108,11 @@ def to_latlon(easting, northing, zone_number, zone_letter=None, northern=None, s
             raise OutOfRangeError('easting out of range (must be between 100.000 m and 999.999 m)')
         if not in_bounds(northing, 0, 10000000):
             raise OutOfRangeError('northing out of range (must be between 0 m and 10.000.000 m)')
-    if not 1 <= zone_number <= 60:
-        raise OutOfRangeError('zone number out of range (must be between 1 and 60)')
-
+    
+    check_valid_zone(zone_number, zone_letter)
+    
     if zone_letter:
         zone_letter = zone_letter.upper()
-
-        if not 'C' <= zone_letter <= 'X' or zone_letter in ['I', 'O']:
-            raise OutOfRangeError('zone letter out of range (must be between C and X)')
-
         northern = (zone_letter >= 'N')
 
     x = easting - 500000
@@ -183,6 +190,8 @@ def from_latlon(latitude, longitude, force_zone_number=None, force_zone_letter=N
         raise OutOfRangeError('latitude out of range (must be between 80 deg S and 84 deg N)')
     if not in_bounds(longitude, -180.0, 180.0):
         raise OutOfRangeError('longitude out of range (must be between 180 deg W and 180 deg E)')
+    if force_zone_number is not None:
+        check_valid_zone(force_zone_number, force_zone_letter)
 
     lat_rad = mathlib.radians(latitude)
     lat_sin = mathlib.sin(lat_rad)


### PR DESCRIPTION
When using `force_zone_number` or `force_zone_letter` in `from_latlon()`, there is no check to make sure the inputs are valid.  I broke that into a separate function and added unit tests for that function individually, and in failing cases to `from_latlon()`.  No other tests broke, so it should be working as expected.