### PR TITLE
Add zone_letter_to_central_latitude

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
+dist: xenial
 language: python
 python:
-  - "3.6"
-  - "3.5"
-  - "3.4"
-  - "3.3"
-  - "2.7"
-  - "2.6"
+  - 3.7
+  - 3.6
+  - 3.5
+  - 3.4
+  - 2.7
+
 env:
   - USE_NUMPY=0
   - USE_NUMPY=1

--- a/test/test_utm.py
+++ b/test/test_utm.py
@@ -335,5 +335,21 @@ class TestForcingZones(unittest.TestCase):
         self.assert_zone_equal(UTM.from_latlon(40.71435, -74.00597, 18, 'u'), 18, 'U')
         self.assert_zone_equal(UTM.from_latlon(40.71435, -74.00597, 18, 'S'), 18, 'S')
 
+
+class TestCentroidConversions(unittest.TestCase):
+    def test_num_to_lon(self):
+        self.assertEqual(UTM.zone_number_to_central_longitude(1),  -177)
+        self.assertEqual(UTM.zone_number_to_central_longitude(12), -111)
+        self.assertEqual(UTM.zone_number_to_central_longitude(16),  -87)
+        self.assertEqual(UTM.zone_number_to_central_longitude(31),    3)
+        self.assertEqual(UTM.zone_number_to_central_longitude(37),   39)
+
+    def test_letter_to_lat(self):
+        self.assertEqual(UTM.zone_letter_to_central_latitude('X'),  78)
+        self.assertEqual(UTM.zone_letter_to_central_latitude('C'), -76)
+        self.assertEqual(UTM.zone_letter_to_central_latitude('E'), -60)
+        self.assertEqual(UTM.zone_letter_to_central_latitude('F'), -52)
+        self.assertEqual(UTM.zone_letter_to_central_latitude('Q'),  20)
+
 if __name__ == '__main__':
     unittest.main()

--- a/utm/__init__.py
+++ b/utm/__init__.py
@@ -1,2 +1,2 @@
-from utm.conversion import to_latlon, from_latlon, latlon_to_zone_number, latitude_to_zone_letter, check_valid_zone
+from utm.conversion import to_latlon, from_latlon, latlon_to_zone_number, latitude_to_zone_letter, check_valid_zone, zone_number_to_central_longitude, zone_letter_to_central_latitude
 from utm.error import OutOfRangeError

--- a/utm/conversion.py
+++ b/utm/conversion.py
@@ -50,15 +50,21 @@ def in_bounds(x, lower, upper, upper_strict=False):
     return lower <= x <= upper
 
 
-def check_valid_zone(zone_number, zone_letter):
+def check_valid_zone_letter(zone_letter):
+    zone_letter = zone_letter.upper()
+    if not 'C' <= zone_letter <= 'X' or zone_letter in ['I', 'O']:
+        raise OutOfRangeError('zone letter out of range (must be between C and X)')
+
+
+def check_valid_zone_number(zone_number):
     if not 1 <= zone_number <= 60:
         raise OutOfRangeError('zone number out of range (must be between 1 and 60)')
 
-    if zone_letter:
-        zone_letter = zone_letter.upper()
 
-        if not 'C' <= zone_letter <= 'X' or zone_letter in ['I', 'O']:
-            raise OutOfRangeError('zone letter out of range (must be between C and X)')
+def check_valid_zone(zone_number, zone_letter):
+    check_valid_zone_number(zone_number)
+    if zone_letter:
+        check_valid_zone_letter(zone_letter)
 
 
 def mixed_signs(x):
@@ -284,9 +290,11 @@ def latlon_to_zone_number(latitude, longitude):
 
 
 def zone_number_to_central_longitude(zone_number):
+    check_valid_zone_number(zone_number)
     return (zone_number - 1) * 6 - 180 + 3
 
 def zone_letter_to_central_latitude(zone_letter):
+    check_valid_zone_letter(zone_letter)
     if zone_letter == 'X':
         return 78
     else:

--- a/utm/conversion.py
+++ b/utm/conversion.py
@@ -285,3 +285,9 @@ def latlon_to_zone_number(latitude, longitude):
 
 def zone_number_to_central_longitude(zone_number):
     return (zone_number - 1) * 6 - 180 + 3
+
+def zone_letter_to_central_latitude(zone_letter):
+    if zone_letter == 'X':
+        return 78
+    else:
+        return -76 + (ZONE_LETTERS.index(zone_letter) * 8)


### PR DESCRIPTION
I'm working on a project involving zone centroids, so I figured I'd implement the sister function to ``zone_number_to_central_longitude``.

Implements the special case of [zone X being 4 degrees taller than the other latitude bands.](https://en.wikipedia.org/wiki/Universal_Transverse_Mercator_coordinate_system#Latitude_bands_2)