### PR TITLE
Fix issue near anti-meridian when forcing zones

### DIFF
--- a/test/test_utm.py
+++ b/test/test_utm.py
@@ -335,5 +335,22 @@ class TestForcingZones(unittest.TestCase):
         self.assert_zone_equal(UTM.from_latlon(40.71435, -74.00597, 18, 'u'), 18, 'U')
         self.assert_zone_equal(UTM.from_latlon(40.71435, -74.00597, 18, 'S'), 18, 'S')
 
+
+class TestForcingAntiMeridian(unittest.TestCase):
+    def assert_equal_lon(self, result, expected_lon):
+        _, lon = UTM.to_latlon(*result[:4], strict=False)
+        self.assertAlmostEqual(lon, expected_lon, 4)
+
+    def test_force_east(self):
+        # Force point just west of anti-meridian to east zone 1
+        self.assert_equal_lon(
+            UTM.from_latlon(0, 179.9, 1, 'N'), 179.9)
+
+    def test_force_west(self):
+        # Force point just east of anti-meridian to west zone 60
+        self.assert_equal_lon(
+            UTM.from_latlon(0, -179.9, 60, 'N'), -179.9)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/utm/conversion.py
+++ b/utm/conversion.py
@@ -71,6 +71,11 @@ def negative(x):
     return x < 0
 
 
+def mod_angle(value):
+    """Returns angle in radians to be between -pi and pi"""
+    return (value + mathlib.pi) % (2 * mathlib.pi) - mathlib.pi
+
+
 def to_latlon(easting, northing, zone_number, zone_letter=None, northern=None, strict=True):
     """This function convert an UTM coordinate into Latitude and Longitude
 
@@ -164,8 +169,10 @@ def to_latlon(easting, northing, zone_number, zone_letter=None, northern=None, s
                  d3 / 6 * (1 + 2 * p_tan2 + c) +
                  d5 / 120 * (5 - 2 * c + 28 * p_tan2 - 3 * c2 + 8 * E_P2 + 24 * p_tan4)) / p_cos
 
+    longitude = mod_angle(longitude + mathlib.radians(zone_number_to_central_longitude(zone_number)))
+
     return (mathlib.degrees(latitude),
-            mathlib.degrees(longitude) + zone_number_to_central_longitude(zone_number))
+            mathlib.degrees(longitude))
 
 
 def from_latlon(latitude, longitude, force_zone_number=None, force_zone_letter=None):
@@ -218,7 +225,7 @@ def from_latlon(latitude, longitude, force_zone_number=None, force_zone_letter=N
     n = R / mathlib.sqrt(1 - E * lat_sin**2)
     c = E_P2 * lat_cos**2
 
-    a = lat_cos * (lon_rad - central_lon_rad)
+    a = lat_cos * mod_angle(lon_rad - central_lon_rad)
     a2 = a * a
     a3 = a2 * a
     a4 = a3 * a


### PR DESCRIPTION
This resolves an issue with zones near the anti-meridian when converting points on the opposing side due to forcing zones. The cause was due to the difference in angle being incorrectly calculated e.g. difference between a longitude of 179 and -179 should be 2, not -358.

This change also ensures that longitudes returned are ≥ -180 and < 180