### PR TITLE
Make sure numpy northing array is not modified in place in `to_latlon`

### DIFF
--- a/test/test_utm.py
+++ b/test/test_utm.py
@@ -356,3 +356,16 @@ def test_force_west():
 
 def test_version():
     assert isinstance(UTM.__version__, str) and "." in UTM.__version__
+
+
+@pytest.mark.skipif(not use_numpy, reason="numpy not installed")
+def test_numpy_args_not_modified():
+    TEST_EASTING = 387358.0
+    TEST_NORTHING = 8145567.0
+    easting = np.array(TEST_EASTING)
+    northing = np.array(TEST_NORTHING)
+    zone = 55
+    letter = "K"
+    UTM.to_latlon(easting, northing, zone, letter)
+    assert easting == TEST_EASTING
+    assert northing == TEST_NORTHING

--- a/utm/conversion.py
+++ b/utm/conversion.py
@@ -133,10 +133,7 @@ def to_latlon(easting, northing, zone_number, zone_letter=None, northern=None, s
         northern = (zone_letter >= 'N')
 
     x = easting - 500000
-    y = northing
-
-    if not northern:
-        y = y - 10000000
+    y = northing if northern else northing - 10000000
 
     m = y / K0
     mu = m / (R * M1)

--- a/utm/conversion.py
+++ b/utm/conversion.py
@@ -136,7 +136,7 @@ def to_latlon(easting, northing, zone_number, zone_letter=None, northern=None, s
     y = northing
 
     if not northern:
-        y -= 10000000
+        y = y - 10000000
 
     m = y / K0
     mu = m / (R * M1)


### PR DESCRIPTION
We were using these eastings / northings (in `np.array`s) after calling the `to_latlon` function and noticed that the northing was being modified. I'm not sure if this is actually intended to be supported in UTM, but I don't think it should be modified as an arg.  It seems like the `-=` operator here was optimized to modify the northings in place, which was a problem for us. Given that the easting is not modified in place, I think it make sense to do it this way instead. 