### PR TITLE
Use ubuntu-20.04 as GA test runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           - false
 
     name: "Tests (Python v${{ matrix.python-version }}, NumPy: ${{ matrix.numpy }})"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
Experimenting in my fork confirms it was Github's roll out of ubuntu-22.04 did break the CI tests.  ubuntu-18.04 is not necessary.

Fixes #97 