### PR TITLE
Add long_description to improve utm PyPi page

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,10 @@
-from distutils.core import setup
+from setuptools import setup
 
 from utm._version import __version__
 
+from pathlib import Path
+this_directory = Path(__file__).parent
+long_description = (this_directory / "README.rst").read_text()
 
 setup(
     name='utm',
@@ -10,6 +13,8 @@ setup(
     author_email='Tobias.Bieniek@gmx.de',
     url='https://github.com/Turbo87/utm',
     description='Bidirectional UTM-WGS84 converter for python',
+    long_description=long_description,
+    long_description_content_type='text/x-rst',
     keywords=['utm', 'wgs84', 'coordinate', 'converter'],
     classifiers=[
         'Programming Language :: Python',


### PR DESCRIPTION
setuptools or packing is needed anyway as distutils is deprecated.  This feature of setuptools makes a nice improvement to the PyPi page.

Added code is from PyPA's docs:  
https://packaging.python.org/en/latest/guides/making-a-pypi-friendly-readme/