### PR TITLE
Add CI for Python 3.10 and 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,10 @@ jobs:
       fail-fast: true
       matrix:
         python-version:
+          - "3.11"
+          - "3.10"
           - "3.9"
           - "3.8"
-          - "3.7"
-          - "3.6"
-          - "3.5"
           - "2.7"
         numpy:
           - true


### PR DESCRIPTION
Drop CI for discontinued 3.5, 3.6, and 3.7.

Any chance to drop 2.7 as well?