### PR TITLE
Add CI for Python 3.10 and 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,12 +17,10 @@ jobs:
       fail-fast: true
       matrix:
         python-version:
+          - "3.11"
+          - "3.10"
           - "3.9"
           - "3.8"
-          - "3.7"
-          - "3.6"
-          - "3.5"
-          - "2.7"
         numpy:
           - true
           - false


### PR DESCRIPTION
And drop CI for discontinued Python 3.5, 3.6, 3.7, as well as Python 2.7 (GitHub CI dropped its support already).