### PR TITLE
Fix `latlon_to_zone_number` returning bogus zone 61 for longitude 180

### DIFF
--- a/test/test_utm.py
+++ b/test/test_utm.py
@@ -106,14 +106,14 @@ known_values = [
     (
         (0, 180),
         (166021, 0, 1, "N"),
-        {"northern": True}
+        {"northern": True},
     ),
     # West-most point on the Equator
     (
         (0, -180),
         (166021, 0, 1, "N"),
         {"northern": True}
-    )
+    ),
 ]
 
 

--- a/test/test_utm.py
+++ b/test/test_utm.py
@@ -26,9 +26,6 @@ def assert_utm_equal(a, b):
 
 def assert_latlon_equal(a, b):
     def longitude_close(lon1, lon2, rtol=1e-4, atol=1e-4):
-        # Normalize longitudes to be within the [-180, 180] range
-        lon1 = (lon1 + 180) % 360 - 180
-        lon2 = (lon2 + 180) % 360 - 180
         # Check if longitudes are close after normalization
         is_close = functools.partial(np.isclose, lon1, rtol=rtol, atol=atol)
         return is_close(lon2) or is_close(lon2 - 360) or is_close(lon2 + 360)

--- a/test/test_utm.py
+++ b/test/test_utm.py
@@ -87,6 +87,18 @@ known_values = [
         (377486, 6296562, 30, "V"),
         {"northern": True},
     ),
+    # Bergen, Norway
+    (
+        (60.38952, 5.320675),
+        (297264, 6700454, 32, "V"),
+        {"northern": True},
+    ),
+    # Alkefjellet, Spitsbergen, Svalbard
+    (
+        (79.45574, 18.76338),
+        (576830, 8823320, 33, "X"),
+        {"northern": True},
+    ),
     # Latitude 84
     (
         (84, -5.00601),

--- a/utm/conversion.py
+++ b/utm/conversion.py
@@ -307,6 +307,9 @@ def latlon_to_zone_number(latitude, longitude):
         if isinstance(longitude, mathlib.ndarray):
             longitude = longitude.flat[0]
 
+    # Normalize longitude to be in the range [-180, 180)
+    longitude = (longitude % 360 + 540) % 360 - 180
+
     # Special zone for Norway
     if 56 <= latitude < 64 and 3 <= longitude < 12:
         return 32
@@ -321,11 +324,7 @@ def latlon_to_zone_number(latitude, longitude):
         elif longitude < 42:
             return 37
 
-    zone_number = int((longitude + 180) / 6) + 1
-    # Handle edge case of longitude = 180
-    if zone_number > 60:
-        zone_number = 1
-    return zone_number
+    return int((longitude + 180) / 6) + 1
 
 
 def zone_number_to_central_longitude(zone_number):

--- a/utm/conversion.py
+++ b/utm/conversion.py
@@ -307,9 +307,10 @@ def latlon_to_zone_number(latitude, longitude):
         if isinstance(longitude, mathlib.ndarray):
             longitude = longitude.flat[0]
 
+    # Special zone for Norway
     if 56 <= latitude < 64 and 3 <= longitude < 12:
         return 32
-
+    # Special zones for Svalbard
     if 72 <= latitude <= 84 and longitude >= 0:
         if longitude < 9:
             return 31
@@ -320,7 +321,11 @@ def latlon_to_zone_number(latitude, longitude):
         elif longitude < 42:
             return 37
 
-    return int((longitude + 180) / 6) + 1
+    zone_number = int((longitude + 180) / 6) + 1
+    # Handle edge case of longitude = 180
+    if zone_number > 60:
+        zone_number = 1
+    return zone_number
 
 
 def zone_number_to_central_longitude(zone_number):


### PR DESCRIPTION
Fixes #109 

Note: to test changes locally, I also had to incorporate the changes matching #82.