### PR TITLE
Support current versions of Python

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,12 +17,10 @@ jobs:
       fail-fast: true
       matrix:
         python-version:
+          - "3.11"
+          - "3.10"
           - "3.9"
           - "3.8"
-          - "3.7"
-          - "3.6"
-          - "3.5"
-          - "2.7"
         numpy:
           - true
           - false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: "3.12"
 
       - run: python setup.py sdist
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
       fail-fast: true
       matrix:
         python-version:
+          - "3.12"
           - "3.11"
           - "3.10"
           - "3.9"


### PR DESCRIPTION
Add support for Python 3.10, 3.11, 3.12.
Drop support for EOL versions of Python: 2.7, 3,5, 3.6, 3.7.

This superseeds #103.