### PR TITLE
chore: update dependencies and test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,16 +17,23 @@ jobs:
       fail-fast: true
       matrix:
         python-version:
+          - "3.13"
           - "3.12"
           - "3.11"
           - "3.10"
           - "3.9"
           - "3.8"
-        numpy:
-          - true
+        numpy-version:
           - false
+          - "1.x"
+          - "2.x"
+        exclude:
+          - python-version: "3.13"
+            numpy-version: "1.x"
+          - python-version: "3.8"
+            numpy-version: "2.x"
 
-    name: "Tests (Python v${{ matrix.python-version }}, NumPy: ${{ matrix.numpy }})"
+    name: "Tests (Python v${{ matrix.python-version }}, NumPy: ${{ matrix.numpy-version }})"
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
@@ -37,8 +44,8 @@ jobs:
 
       - run: pip install -r requirements.txt
 
-      - run: pip install -r numpy-requirements.txt
-        if: matrix.numpy == true
+      - run: pip install -r numpy-${{ matrix.numpy-version }}-requirements.txt
+        if: matrix.numpy-version != false
 
       - run: pytest -v --cov=utm --color=yes
 
@@ -53,11 +60,11 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - run: python setup.py sdist
 
-      - uses: pypa/gh-action-pypi-publish@v1.10.3
+      - uses: pypa/gh-action-pypi-publish@v1.12.3
         with:
           user: __token__
           password: ${{ secrets.PYPI_TOKEN }}

--- a/numpy-1.x-requirements.txt
+++ b/numpy-1.x-requirements.txt
@@ -1,0 +1,2 @@
+numpy==1.24.4; python_version < '3.9'
+numpy==1.26.4; python_version >= '3.9' and python_version < '3.13'

--- a/numpy-2.x-requirements.txt
+++ b/numpy-2.x-requirements.txt
@@ -1,0 +1,3 @@
+numpy==2.0.0; python_version >= '3.9' and python_version < '3.10'
+numpy==2.1.0; python_version >= '3.10' and python_version < '3.13'
+numpy==2.2.0; python_version >= '3.13'

--- a/numpy-requirements.txt
+++ b/numpy-requirements.txt
@@ -1,2 +1,0 @@
-numpy==1.24.4; python_version < '3.9'
-numpy==1.26.3; python_version >= '3.9'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-pytest==8.3.3
-pytest-cov==5.0.0
+pytest==8.3.4
+pytest-cov==5.0.0; python_version < '3.9'
+pytest-cov==6.0.0; python_version >= '3.9'


### PR DESCRIPTION
- Update pytest 8.3.{3=>4}
- Update pytest-cov {5=>6}.0.0 for Python >= 3.9
- Update numpy 1.26.{3=>4} for Python >= 3.9
- Add support for numpy 2.x, requires Python >= 3.9
- Add separate test runs for NumPy 1.x and 2.x
- Enable support for Python 3.13
- Update gh-action-pypi-publish 1.1{0=>2}.3 in GitHub Actions config