### PR TITLE
Add zone_letter_to_central_latitude

### DIFF
--- a/test/test_utm.py
+++ b/test/test_utm.py
@@ -478,3 +478,33 @@ def test_numpy_args_not_modified():
     UTM.to_latlon(easting, northing, zone, letter)
     assert easting == TEST_EASTING
     assert northing == TEST_NORTHING
+
+
+@pytest.mark.parametrize(
+    "zone_number, expected_lon",
+    [
+        (1,  -177),
+        (12, -111),
+        (16,  -87),
+        (31,    3),
+        (37,   39),
+    ],
+)
+def test_zone_number_to_central_longitude(zone_number, expected_lon):
+    lon = UTM.zone_number_to_central_longitude(zone_number)
+    assert lon == expected_lon
+
+
+@pytest.mark.parametrize(
+    "zone_letter, expected_lat",
+    [
+        ("X",  78),
+        ("C", -76),
+        ("E", -60),
+        ("F", -52),
+        ("Q",  20),
+    ],
+)
+def test_zone_letter_to_central_latitude(zone_letter, expected_lat):
+    lat = UTM.zone_letter_to_central_latitude(zone_letter)
+    assert lat == expected_lat

--- a/utm/__init__.py
+++ b/utm/__init__.py
@@ -1,3 +1,3 @@
-from utm.conversion import to_latlon, from_latlon, latlon_to_zone_number, latitude_to_zone_letter, check_valid_zone
+from utm.conversion import to_latlon, from_latlon, latlon_to_zone_number, latitude_to_zone_letter, check_valid_zone, zone_number_to_central_longitude, zone_letter_to_central_latitude
 from utm.error import OutOfRangeError
 from utm._version import __version__

--- a/utm/conversion.py
+++ b/utm/conversion.py
@@ -51,15 +51,21 @@ def in_bounds(x, lower, upper, upper_strict=False):
     return lower <= x <= upper
 
 
-def check_valid_zone(zone_number, zone_letter):
+def check_valid_zone_letter(zone_letter):
+    zone_letter = zone_letter.upper()
+    if not 'C' <= zone_letter <= 'X' or zone_letter in ['I', 'O']:
+        raise OutOfRangeError('zone letter out of range (must be between C and X)')
+
+
+def check_valid_zone_number(zone_number):
     if not 1 <= zone_number <= 60:
         raise OutOfRangeError('zone number out of range (must be between 1 and 60)')
 
-    if zone_letter:
-        zone_letter = zone_letter.upper()
 
-        if not 'C' <= zone_letter <= 'X' or zone_letter in ['I', 'O']:
-            raise OutOfRangeError('zone letter out of range (must be between C and X)')
+def check_valid_zone(zone_number, zone_letter):
+    check_valid_zone_number(zone_number)
+    if zone_letter:
+        check_valid_zone_letter(zone_letter)
 
 
 def mixed_signs(x):
@@ -119,9 +125,9 @@ def to_latlon(easting, northing, zone_number, zone_letter=None, northern=None, s
             raise OutOfRangeError('easting out of range (must be between 100,000 m and 999,999 m)')
         if not in_bounds(northing, 0, 10000000):
             raise OutOfRangeError('northing out of range (must be between 0 m and 10,000,000 m)')
-    
+
     check_valid_zone(zone_number, zone_letter)
-    
+
     if zone_letter:
         zone_letter = zone_letter.upper()
         northern = (zone_letter >= 'N')
@@ -331,4 +337,13 @@ def latlon_to_zone_number(latitude, longitude):
 
 
 def zone_number_to_central_longitude(zone_number):
+    check_valid_zone_number(zone_number)
     return (zone_number - 1) * 6 - 180 + 3
+
+def zone_letter_to_central_latitude(zone_letter):
+    check_valid_zone_letter(zone_letter)
+    zone_letter = zone_letter.upper()
+    if zone_letter == 'X':
+        return 78
+    else:
+        return -76 + (ZONE_LETTERS.index(zone_letter) * 8)


### PR DESCRIPTION
Supersedes #41, which was created a long time ago, in 2019. Due to various updates, it could no longer be applied. This PR simply takes the relevant changes from that effort and adds up-to-date unit tests (also converted from tests in the original request).

For details, see original pull request.