### PR TITLE
add python_version metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,5 +27,6 @@ setup(
         'Topic :: Scientific/Engineering :: GIS',
     ],
     packages=['utm'],
+    python_requires=">=3",
     scripts=['scripts/utm-converter'],
 )


### PR DESCRIPTION
Add python version requirements so that pypi can pickup this information. Those python2 users won't get error when `pip install utm`