### PR TITLE
fix: from_latlon mis-reads a lowercase forced zone letter as northern

### DIFF
--- a/test/test_utm.py
+++ b/test/test_utm.py
@@ -418,6 +418,11 @@ def test_force_south():
         UTM.from_latlon(0.1, 0, 31, force_northern=True), 0.1, northern=True)
 
 
+def test_force_south_lowercase_letter():
+    # Force northern point to a lowercase southern zone letter
+    assert_equal_lat(UTM.from_latlon(0.1, 0, 31, 'm'), 0.1)
+
+
 @pytest.mark.skipif(not use_numpy, reason="numpy not installed")
 def test_no_force_numpy():
     # Point above and below equator

--- a/utm/conversion.py
+++ b/utm/conversion.py
@@ -255,7 +255,7 @@ def from_latlon(latitude, longitude, force_zone_number=None, force_zone_letter=N
         zone_letter = force_zone_letter
 
     if force_northern is None:
-        northern = (zone_letter >= 'N')
+        northern = (zone_letter.upper() >= 'N')
     else:
         northern = force_northern
 


### PR DESCRIPTION
`from_latlon(..., force_zone_letter=...)` derives the hemisphere straight from the forced letter without normalizing case:

```python
northern = (zone_letter >= 'N')
```

Every lowercase ASCII letter is `>= 'N'`, so a lowercase **southern**-band letter (c–m) is mis-classified as northern and the 10,000,000 m false-northing offset is dropped — a 10,000 km error. Uppercase letters, and lowercase northern letters (n–x), happen to work.

```python
>>> import utm
>>> utm.from_latlon(-30, 10, force_zone_letter='M')[1]
6680793.78
>>> utm.from_latlon(-30, 10, force_zone_letter='m')[1]
-3319206.22          # 10,000,000 m off; utm.to_latlon() then rejects it
```

Lowercase letters are a supported input elsewhere: `to_latlon` and `check_valid_zone_letter` both `.upper()` the letter first, and the test suite already forces lowercase `'u'`. `from_latlon` was the lone case-sensitive spot.

Fix is `northern = (zone_letter.upper() >= 'N')`. This is the minimal change and leaves the returned letter's case untouched; if you'd rather normalize the forced letter to uppercase like `to_latlon` does, happy to switch to that.

Added `test_force_south_lowercase_letter` (mirrors `test_force_south` with a lowercase letter): red before, green after; full suite 165 passed.

---

Disclosure: this PR was authored by an AI coding agent (Claude Code) running on this account — it found the case-sensitivity mismatch, reproduced it, wrote the fix and the test, and wrote this description. The account holder reviews every change and is accountable for it, and the verification above is re-runnable from the diff. Happy to close it if it isn't the kind of contribution you want.
